### PR TITLE
Add a "borderOffset" property which shifts the border in/out

### DIFF
--- a/GRKCircularGraphView/GRKCircularGraphBackingLayer.h
+++ b/GRKCircularGraphView/GRKCircularGraphBackingLayer.h
@@ -29,6 +29,11 @@
  */
 @property (nonatomic,assign) CGFloat borderThickness;
 /**
+ *  A radial offset to draw border at. Negative values shrink the radius.
+ *  This defaults to 0.0.
+ */
+@property (nonatomic,assign) CGFloat borderOffset;
+/**
  *  The color to use to fill the circle background.
  */
 @property (nonatomic,assign) CGColorRef fillColor;

--- a/GRKCircularGraphView/GRKCircularGraphBackingLayer.m
+++ b/GRKCircularGraphView/GRKCircularGraphBackingLayer.m
@@ -22,7 +22,7 @@ static CGFloat const kDefaultBorderThickness = 1.0f;
 
 @implementation GRKCircularGraphBackingLayer
 
-@dynamic color, fillColor, borderThickness;
+@dynamic color, fillColor, borderThickness, borderOffset;
 
 #pragma mark - Class Level
 
@@ -31,7 +31,7 @@ static CGFloat const kDefaultBorderThickness = 1.0f;
     static NSSet *keys = nil;
     if (!keys)
     {
-        keys = [NSSet setWithObjects:@"color", @"fillColor", @"borderThickness", @"bounds", nil];
+        keys = [NSSet setWithObjects:@"color", @"fillColor", @"borderThickness", @"borderOffset", @"bounds", nil];
     }
     
     return keys;
@@ -70,6 +70,7 @@ static CGFloat const kDefaultBorderThickness = 1.0f;
         self.color = baseLayer.color;
         self.fillColor = baseLayer.fillColor;
         self.borderThickness = baseLayer.borderThickness;
+		self.borderOffset = baseLayer.borderOffset;
     }
     return self;
 }
@@ -107,7 +108,7 @@ static CGFloat const kDefaultBorderThickness = 1.0f;
         //The radius (minimum of center.x and center.y so we will not draw out of bounds)
         CGFloat radius = MIN(center.y, center.x);
         //Adjust the radius for the line width (again so we don't draw out of bounds)
-        radius -= self.borderThickness / 2.0f;
+        radius -= (self.borderThickness / 2.0f - self.borderOffset);
         
         UIBezierPath *path = [UIBezierPath bezierPathWithArcCenter:center radius:radius startAngle:0.0f endAngle:2.0f * M_PI clockwise:YES];
         

--- a/GRKCircularGraphView/GRKCircularGraphBackingLayer.m
+++ b/GRKCircularGraphView/GRKCircularGraphBackingLayer.m
@@ -108,7 +108,7 @@ static CGFloat const kDefaultBorderThickness = 1.0f;
         //The radius (minimum of center.x and center.y so we will not draw out of bounds)
         CGFloat radius = MIN(center.y, center.x);
         //Adjust the radius for the line width (again so we don't draw out of bounds)
-        radius -= (self.borderThickness / 2.0f - self.borderOffset);
+        radius -= (self.borderThickness / 2.0f) - self.borderOffset;
         
         UIBezierPath *path = [UIBezierPath bezierPathWithArcCenter:center radius:radius startAngle:0.0f endAngle:2.0f * M_PI clockwise:YES];
         

--- a/GRKCircularGraphView/GRKCircularGraphView.h
+++ b/GRKCircularGraphView/GRKCircularGraphView.h
@@ -60,6 +60,11 @@
  */
 @property (nonatomic) CGFloat borderThickness;
 /**
+ *  A radial offset to draw border at. Negative values shrink the radius.
+ *  This defaults to 0.0.
+ */
+@property (nonatomic,assign) CGFloat borderOffset;
+/**
  *  The color to use to fill the circle background (can be `nil`).
  */
 @property (nonatomic,strong) UIColor *fillColor;

--- a/GRKCircularGraphView/GRKCircularGraphView.m
+++ b/GRKCircularGraphView/GRKCircularGraphView.m
@@ -165,6 +165,16 @@
     self.backingLayer.borderThickness = borderThickness;
 }
 
+- (CGFloat)borderOffset
+{
+	return self.backingLayer.borderOffset;
+}
+
+- (void)setBorderOffset:(CGFloat)borderOffset
+{
+	self.backingLayer.borderOffset = borderOffset;
+}
+
 - (UIColor *)fillColor
 {
     return [UIColor colorWithCGColor:self.backingLayer.fillColor];


### PR DESCRIPTION
Hello, thank you for your circular graph view. I came across a need to be able to outside edge of the border circle with the outside edge of the indicator, so I added a new *borderOffset* property. I thought you might find this a useful addition, so here's a PR with the change.

I also hacked the demo quickly to show this in action, but not in a very nicely organized way so I left that in a [different branch](/Blue-Rocket/GRKCircularGraphView/tree/feature/border-offset-demo) so you didn't have to merge that.

Cheers,
Matt